### PR TITLE
make toc easier to read

### DIFF
--- a/css/theme.less
+++ b/css/theme.less
@@ -228,6 +228,8 @@ body:not(.mode_show) div.breadcrumbs {
 
 /* TOC */
 #dw__toc {
+    width: 15em;
+
     h3 {
         font-size: 14px;
         margin-bottom: 0;
@@ -238,6 +240,13 @@ body:not(.mode_show) div.breadcrumbs {
     }
     li {
         font-size: 14px;
+    }
+    ul.toc li {
+        list-style: inside square none;
+        line-height: inherit;
+    }
+    ul.toc li.level1 {
+        list-style: outside none none;
     }
     a {
         text-decoration: none;


### PR DESCRIPTION
Since the font-size of writr is larger than the default template, the toc looks too narrow and crowded. This increase the width and line-height of toc and also add bullet to each item to make it easier to read.