### PR TITLE
improve a style for code element(''something'' in DokuWiki)

### DIFF
--- a/css/global.less
+++ b/css/global.less
@@ -130,7 +130,11 @@ code,
 kbd,
 tt,
 var {
-    font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+    font: 0.9em Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+    border: 1px solid #dbdbdb;
+    border-radius: 6px;
+    background-color: #fafafa;
+    padding: 0.5px 4px;
 }
 abbr,
 acronym {


### PR DESCRIPTION
Hi,
Thanks for your great theme for DokuWiki. I'm using your theme well.

However, I have a problem related to code syntax in DokuWiki. I enjoy to use code syntax like ''func()'' in my document of DokuWiki. But, your theme doesn't make a highlight for this syntax unlike other themes of DokuWiki.

So I added my sourcecode for this feature.

Merry Christmas!