### PR TITLE
Fixed style.ini

### DIFF
--- a/style.ini
+++ b/style.ini
@@ -79,6 +79,8 @@ __highlight__      = "#ff9"                 ; @ini_highlight
 __theme_color__     = "#3498db"             ; @ini_theme_color
 __theme_color_alt__ = "#2980b9"             ; @ini_theme_color_alt
 
+__link__            = "#3498db"             ; @ini_link
+
 ; #1abc9c  turquois
 ; #16a085  darker
 

--- a/style.ini
+++ b/style.ini
@@ -30,7 +30,7 @@
 ../dokuwiki/css/_edit.css             = screen
 ../dokuwiki/css/_modal.css            = screen
 ../dokuwiki/css/_forms.css            = screen
-../dokuwiki/css/_admin.css            = screen
+../dokuwiki/css/_admin.less           = screen
 
 css/genericons.less                   = screen
 css/reset.less                        = screen


### PR DESCRIPTION
Fixed style.ini to reflect changes in DokuWiki Release 2017-02-19 "Frusterick Manners" where the _admin.css file of the "dokuwiki" template was replaced with _admin.less